### PR TITLE
#44 and #45 facilitate Exercises, numering, and relate to texts and configs

### DIFF
--- a/workshop/content/docs/publish/first.md
+++ b/workshop/content/docs/publish/first.md
@@ -1,58 +1,137 @@
 ---
-title: Publish your first dataset with pygeoapi
+title: Exercise 1 - Publish your first dataset with pygeoapi
 ---
 
-# Publish your first dataset with pygeoapi
+# Exercise 1 - Publish your first dataset with pygeoapi
 
-In this section you are going to publish a vector dataset using pygeoapi. You can use any dataset or select one of the datasets available in the [/tests/data](https://github.com/geopython/pygeoapi/tree/master/tests/data) folder of the pygeoapi repository.
+In this section you are going to publish a vector dataset using `pygeoapi`.
 
-!!! note
+We will use the CSV dataset [free-wifi-florence.csv](https://github.com/geopython/diving-into-pygeoapi/blob/main/workshop/docker/data/free-wifi-florence.csv), free WIFI
+access points in Florence, kindly provided by https://opendata.comune.fi.it.
+You can find this dataset in the `workshop/docker/data` folder.
 
-    It is important pygeaopi is able to access the data file. This aspect can be challenging if you are running pygeoapi in a docker environment. We recommend to mount a data folder into the docker container. You are most flexible if you also place the pygeoapi config file in that folder. 
+This exercise consists of two major steps:
+
+* adapt the `docker.config.yml` to define this dataset as an OAPIF *Collection*
+* make sure that pygeoapi can find the data file
+
+We will use the `docker-compose.yml` file provided.
+
+## Verify the existing Docker Compose config
+
+Before making any changes, we will make sure that the initial Docker Compose
+setup provided to you is actually working. Two files are relevant:
+
+* `workshop/docker/docker-compose.yml`
+* `pygeoapi/docker.pygeoapi.config`
+
+To test:
+
+* type `docker-compose up`
+* open http://localhost:5000 in your browser, verify datasets
+* close by typing Control-C
+
+NB you may also run the Docker Container in the background (detached):
+
+* type `docker-compose up -d`
+* type `docker ls`, verify `pygeoapi` Container is running
+* open http://localhost:5000 in your browser, verify datasets
+* view logging: `docker logs --follow pygeoapi`
+* `docker-compose stop`
 
 ## Setting up the pygeoapi config file
 
-Before actually publishing a dataset, we'll first go through all the steps involved.
+* Open the file `workshop/docker/pygeoapi/docker.config.yml` in a text editor.
+* Look for the commented config section starting with `# START - EXERCISE 1 - Your First Collection`
+* Uncomment all lines until `# END - EXERCISE 1 - Your First Collection`  
+* make sure that the indentation aligns (hint: directly under `# START ...)
 
-Which datasets are published is managed in the pygeoapi configuration file. pygeoapi comes with a [default configuration file](https://github.com/geopython/pygeoapi/blob/master/pygeoapi-config.yml) including some sample data. You can use this configuration file as a starting point. An environment variable `PYGEOAPI_CONFIG` can be used to indicate to pygeoapi the path to the configuration file to be used. This parameter can be set using:
+The config section reads:
 
-```
-export PYGEOAPI_CONFIG=/home/user/workshop-config.yml
-```
+    free_wifi_florence:
+      type: collection
+      title: Free WIFI Florence
+      description: The dataset shows the location of the places in the Municipality of Florence where a free wireless internet connection service (Wifi) is available.
+      keywords:
+          - wifi
+          - florence
+      links:
+          - type: text/csv
+            rel: canonical
+            title: data
+            href: https://opendata.comune.fi.it/?q=metarepo/datasetinfo&id=fb5b7bac-bcb0-4326-9388-7e3f3d671d71
+            hreflang: it-IT
+      extents:
+          spatial:
+              bbox: [11, 43.6, 11.4, 43.9]
+              crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+      providers:
+          - type: feature
+            name: CSV
+            data: /data/free-wifi-florence.csv
+            id_field: name-it
+            geometry:
+                x_field: lon
+                y_field: lat
 
-Then (re)start the pygeoapi service with `pygeoapi serve` and validate the result in a browser, e.g. `http://localhost:5000`
+The most relevant part is the `providers` section. Here we define a *CSV Provider*,
+pointing the file path to the `/data` directory we will mount (see next) from the local
+dir into the Docker Container above. As a CSV is not a spatial file, we tell `pygeoapi`
+that the longitude and latitude (x,y) is mapped from the columns `lon` and `lat`.
 
-!!! note
+!!! Tip
 
-    Setting an environment variable in a docker container is possible by adding `-e PYGEOAPI_CONFIG=/home/user/workshop-config.yml` to the docker run statement. Notice that the path should refer to a folder within the container. This can be a mounted folder.
+    To learn more about the `pygeoapi` configuration syntax and conventions see
+    the [relevant chapter in the documentation](https://docs.pygeoapi.io/en/latest/configuration.html).
 
-## Dataset providers
+!!! Tip
 
-pygeoapi includes a [number of data providers](https://docs.pygeoapi.io/en/latest/data-publishing/ogcapi-features.html#providers) which enable access to a variety of data formats. Via the OGR/GDAL plugin the number of supported formats is almost limitless.
+    pygeoapi includes a [number of data providers](https://docs.pygeoapi.io/en/latest/data-publishing/ogcapi-features.html#providers) which enable access to a variety of data formats. Via the OGR/GDAL plugin the number of supported formats is almost limitless.
+    Read on the [data provider page](https://docs.pygeoapi.io/en/latest/data-publishing/ogcapi-features.html#providers) how you can set up a connection to your dataset of choice. You can always copy a relevant example configuration and place it in the datasets section of the pygeoapi config file for your future project.
 
-Read on the [data provider page](https://docs.pygeoapi.io/en/latest/data-publishing/ogcapi-features.html#providers) how you can set up a connection to your dataset of choice. You can copy the relevant example configuration and place it in the datasets section of the pygeoapi config file. For example for a CSV file, this section is relevant.
+## Making configuration and data available in the Docker Container
 
-``` {.yaml linenums="134"}
-providers:
-    - type: feature
-      name: CSV
-      data: tests/data/obs.csv
-      id_field: id
-      geometry:
-          x_field: long
-          y_field: lat
-```
+As the Docker Container, here named `pygeoapi`, cannot directly access files on your
+local host system, we will use *Docker Volume Mounts*. This can be defined 
+in the `docker-compose.yml` file:
 
-Save the file, restart the service and check the reult in the brower. The new dataset should now be available in the http://localhost:5000/collections endpoint. Also drill down to the individual items of the collection, to evaluate if the connection works smoothly.
+* open the file `workshop/docker/docker-compose.yml`
+* look for the commented section `# Exercise 1 - `
+* uncomment that line  `- ./data:/data`
+
+The relevant lines read:
+
+    volumes:
+      - ./pygeoapi/docker.config.yml:/pygeoapi/local.config.yml
+      - ./data:/data # Exercise 1 - Ready to pull data from here
+
+The local `./pygeoapi/docker.config.yml` file was already mounted. Now
+we have also mounted (made available) the entire local directory `./data`.
+
+## Test
+
+Moment of truth!
+
+* start by typing `docker-compose up` 
+* observe logging output
+* if no errors: open http://localhost:5000
+* look for the Free WIFI Collection
+* browse through the collection
 
 ## Debugging configuration errors
 
-Incidentally you may run into configuration errors. A file can not be found, a typo in the configuration, or the file format is not fully supported. There are 2 parameters in the config file which help to address these issues. You can set the logging level to `DEBUG` and indicate a path to a log file. 
+Incidentally you may run into various errors, breifly discussed here:
+
+* A file can not be found, a typo in the configuration, 
+* the file format is not fully supported. 
+
+* There are 2 parameters in the config file which help to address these issues. 
+You can set the logging level to `DEBUG` and indicate a path to a log file. 
 
 !!! tip
 
-    On docker, set the path of the logfile to the mounted folder, so you can easilty access it from your host system. You can also view the console logs from your docker container using `docker logs {container}`
+    On docker, set the path of the logfile to the mounted folder, so you can easily access it from your host system. You can also view the console logs from your docker container using `docker logs --follow pygoapi`
 
 !!! tip
 
-    Errors related to file paths likely happen at incidental setup. However they can also happen at unexpected moments, resulting in a broken service. Products like [GeoHealthCheck](https://github.com/geopython/GeoHealthCheck) aim to detect this type of unexpected errors. The OGC APi Features test in GeoHealthCheck polls the availability of the service at intervals  
+    Errors related to file paths likely happen at incidental setup. However they can also happen at unexpected moments, resulting in a broken service. Products like [GeoHealthCheck](https://github.com/geopython/GeoHealthCheck) aim to detect this type of unexpected errors. The OGC APi Features test in GeoHealthCheck polls the availability of the service at intervals.  

--- a/workshop/content/docs/publish/index.md
+++ b/workshop/content/docs/publish/index.md
@@ -4,11 +4,12 @@ title: Publishing data
 
 # Publishing Data
 
-In this section, you will learn how-to publish different types of geospatial information.
+In this section, you will learn how-to publish different types of geospatial information
+through the Exercises below.
 
-- [Publish your first dataset with pygeoapi](first.md)
-- [Vector data](vector.md)
-- [Raster data](raster.md)
-- [Tiles of geospatial information](tiles.md)
-- [Metadata](metadata.md)
-- [Environmental data](env.md) 
+- [Exercise 1 - Publish first dataset](first.md)
+- [Exercise 2 - Vector data](vector.md)
+- [Exercise 3 - Raster data](raster.md)
+- [Exercise 4 - Tiles of geospatial information](tiles.md)
+- [Exercise 5 - Metadata](metadata.md)
+- [Exercise 6 - Environmental data](env.md) 

--- a/workshop/docker/docker-compose.yml
+++ b/workshop/docker/docker-compose.yml
@@ -35,19 +35,19 @@ services:
   pygeoapi:
     image: geopython/pygeoapi:latest
 
-    container_name: pygeoapi_es
-
-    # entrypoint:
-    #   - /es-entrypoint.sh
+    container_name: pygeoapi
 
     ports:
       - 5000:80
 
     volumes:
       - ./pygeoapi/docker.config.yml:/pygeoapi/local.config.yml
-      - ./pygeoapi/es-entrypoint.sh:/es-entrypoint.sh
-      # - ./pygeoapi/wait-for-elasticsearch.sh:/wait-for-elasticsearch.sh
-      - ./data:/data # Ready to pull data from here
+     # - ./data:/data # Exercise 1 - Ready to pull data from here
+     # - ./pygeoapi/es-entrypoint.sh:/es-entrypoint.sh
+     # - ./pygeoapi/wait-for-elasticsearch.sh:/wait-for-elasticsearch.sh
+
+    # entrypoint:
+    #   - /es-entrypoint.sh
 
     # links:
     #   - elastic_search
@@ -67,8 +67,8 @@ services:
   #     - elastic_search_data:/usr/share/elasticsearch/data
   #     - ./data:/data # Ready to pull data from here
 
-volumes:
-  elastic_search_data: {}
+#volumes:
+#  elastic_search_data: {}
 
 #NOTE: Host requires changes in configuration to run ES
 #sudo sysctl -w vm.max_map_count=262144

--- a/workshop/docker/pygeoapi/docker.config.yml
+++ b/workshop/docker/pygeoapi/docker.config.yml
@@ -86,107 +86,40 @@ metadata:
         role: pointOfContact
 
 resources:
+    # ==== START - STANDARD PYGEOAPI COLLECTIONS ====
     obs:
-        type: collection
-        title: Observations
-        description: My cool observations
-        keywords:
-            - observations
-            - monitoring
-        links:
-            - type: text/csv
-              rel: canonical
-              title: data
-              href: https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv
-              hreflang: en-US
-            - type: text/csv
-              rel: alternate
-              title: data
-              href: https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv
-              hreflang: en-US
-        extents:
-            spatial:
-                bbox: [-180,-90,180,90]
-                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
-            temporal:
-                begin: 2000-10-30T18:24:39Z
-                end: 2007-10-30T08:57:29Z
-                trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
-        providers:
-            - type: feature
-              name: CSV
-              data: tests/data/obs.csv
-              id_field: id
-              geometry:
-                  x_field: long
-                  y_field: long
-
-    # example_catalog:
-    #     type: collection
-    #     title: FOSS4G Florence Record catalog
-    #     description: FOSS4G Florence Record catalog (OGC API Records)
-    #     keywords:
-    #         - Services
-    #         - Infrastructures
-    #         - Florence
-    #         - FOSS4G
-    #     links:
-    #         - type: text/html
-    #           rel: canonical
-    #           title: information
-    #           href: http://opendata.comune.firenze.it
-    #           hreflang: en-US
-    #     extents:
-    #         spatial:
-    #             bbox: [11.145, 43.718, 11.348, 43.84]
-    #             crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
-    #     providers:
-    #         - type: record
-    #           name: Elasticsearch
-    #           data: http://elastic_search:9200/catalogue
-    #           id_field: id
-    #           time_field: datetime
-
-
-    # Cycle:
-    #     type: collection
-    #     title: Cycle Circulation Area in Florence
-    #     description: Cycle lanes and other cycle paths in the city of Florence.
-    #     keywords:
-    #         - cycle
-    #     links:
-    #         - type: text/html
-    #           rel: canonical
-    #           title: information
-    #           href: http://opendata.comune.firenze.it/?q=metarepo/datasetinfo&id=52d8d3ab-eae5-400e-8561-d974f8612de0
-    #           hreflang: en-US
-    #     extents:
-    #         spatial:
-    #             bbox: [-180,-90,180,90]
-    #             crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
-    #         temporal:
-    #             begin: 2011-11-11
-    #             end: null  # or empty
-    #     providers:
-    #         - type: feature
-    #           name: GeoJSON
-    #           data: /data/cycle-lanes-firenze.geojson
-    #           #id_field: field_1
-    #         - type: tile
-    #           name: MVT
-    #           data: /data/tiles
-    #           #data: tests/data/tiles/DATASET
-    #           options:
-    #             metadata_format: tilejson # default | tilejson
-    #             bounds: [[11.1861935050234251,43.7512761718001855],[11.3125196304517655,43.8129406631082645]]
-    #             zoom:
-    #                 min: 0
-    #                 max: 16
-    #             schemes:
-    #                 - WorldCRS84Quad
-    #           format:
-    #                 name: pbf
-    #                 mimetype: application/vnd.mapbox-vector-tile
+      type: collection
+      title: Observations
+      description: My cool observations
+      keywords:
+          - observations
+          - monitoring
+      links:
+          - type: text/csv
+            rel: canonical
+            title: data
+            href: https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv
+            hreflang: en-US
+          - type: text/csv
+            rel: alternate
+            title: data
+            href: https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv
+            hreflang: en-US
+      extents:
+          spatial:
+              bbox: [-140,0,-60,60]
+              crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+          temporal:
+              begin: 2000-10-30T18:24:39Z
+              end: 2007-10-30T08:57:29Z
+      providers:
+          - type: feature
+            name: CSV
+            data: tests/data/obs.csv
+            id_field: id
+            geometry:
+                x_field: long
+                y_field: lat
 
     lakes:
         type: collection
@@ -241,7 +174,110 @@ resources:
               id_field: ogc_fid
               table: ne_110m_admin_0_countries
 
-    hello-world:
-        type: process
-        processor:
-            name: HelloWorld
+    # ==== END - STANDARD PYGEOAPI COLLECTIONS ====
+
+
+    # ==== START - WORKSHOP EXERCISES ====
+    # Uncomment a config section between START and END for each exercise.
+    # Make sure that indentation matches!
+
+    # START - EXERCISE 1 - Your First Collection
+#    free_wifi_florence:
+#      type: collection
+#      title: Free WIFI Florence
+#      description: The dataset shows the location of the places in the Municipality of Florence where a free wireless internet connection service (Wifi) is available.
+#      keywords:
+#          - wifi
+#          - florence
+#      links:
+#          - type: text/csv
+#            rel: canonical
+#            title: data
+#            href: https://opendata.comune.fi.it/?q=metarepo/datasetinfo&id=fb5b7bac-bcb0-4326-9388-7e3f3d671d71
+#            hreflang: it-IT
+#      extents:
+#          spatial:
+#              bbox: [11, 43.6, 11.4, 43.9]
+#              crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+#      providers:
+#          - type: feature
+#            name: CSV
+#            data: /data/free-wifi-florence.csv
+#            id_field: name-it
+#            geometry:
+#                x_field: lon
+#                y_field: lat
+    # END - EXERCISE 1 - Your First Collection
+
+    # example_catalog:
+    #     type: collection
+    #     title: FOSS4G Florence Record catalog
+    #     description: FOSS4G Florence Record catalog (OGC API Records)
+    #     keywords:
+    #         - Services
+    #         - Infrastructures
+    #         - Florence
+    #         - FOSS4G
+    #     links:
+    #         - type: text/html
+    #           rel: canonical
+    #           title: information
+    #           href: http://opendata.comune.firenze.it
+    #           hreflang: en-US
+    #     extents:
+    #         spatial:
+    #             bbox: [11.145, 43.718, 11.348, 43.84]
+    #             crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+    #     providers:
+    #         - type: record
+    #           name: Elasticsearch
+    #           data: http://elastic_search:9200/catalogue
+    #           id_field: id
+    #           time_field: datetime
+
+
+#    Cycle:
+#        type: collection
+#        title: Cycle Circulation Area in Florence
+#        description: Cycle lanes and other cycle paths in the city of Florence.
+#        keywords:
+#            - cycle
+#        links:
+#            - type: text/html
+#              rel: canonical
+#              title: information
+#              href: http://opendata.comune.firenze.it/?q=metarepo/datasetinfo&id=52d8d3ab-eae5-400e-8561-d974f8612de0
+#              hreflang: en-US
+#        extents:
+#            spatial:
+#                bbox: [-180,-90,180,90]
+#                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+#            temporal:
+#                begin: 2011-11-11
+#                end: null  # or empty
+#        providers:
+#            - type: feature
+#              name: GeoJSON
+#              data: /data/cycle-lanes-firenze.geojson
+#              #id_field: field_1
+#            - type: tile
+#              name: MVT
+#              data: /data/tiles
+#              #data: tests/data/tiles/DATASET
+#              options:
+#                metadata_format: tilejson # default | tilejson
+#                bounds: [[11.1861935050234251,43.7512761718001855],[11.3125196304517655,43.8129406631082645]]
+#                zoom:
+#                    min: 0
+#                    max: 16
+#                schemes:
+#                    - WorldCRS84Quad
+#              format:
+#                    name: pbf
+#                    mimetype: application/vnd.mapbox-vector-tile
+
+#
+#    hello-world:
+#        type: process
+#        processor:
+#            name: HelloWorld


### PR DESCRIPTION
This PR provides:

* make initial `docker-compose.yml` and `docker.config.yml` working
* add 'First' Exercise
* start numbering system for Exercises, also to easily find the sections to be commented out
* rewrote `first.md` section

