### PR TITLE
#98 OWSLib in Docker Python Container - setup doc and refs

### DIFF
--- a/workshop/content/docs/publishing/ogcapi-coverages.md
+++ b/workshop/content/docs/publishing/ogcapi-coverages.md
@@ -96,7 +96,7 @@ Save the configuration and restart docker compose. Navigate to `http://localhost
 
 !!! question "Interact with OGC API - Coverages via OWSLib"
 
-    If you do not have Python installed, consider running this exercise in a Docker container or in a cloud environment. 
+    If you do not have Python installed, consider running this exercise in a Docker container. See the [Setup Chapter](../setup.md#using-docker-for-python-clients). 
 
     <div class="termy">
     ```bash

--- a/workshop/content/docs/publishing/ogcapi-features.md
+++ b/workshop/content/docs/publishing/ogcapi-features.md
@@ -236,7 +236,7 @@ QGIS is one of the first GIS Desktop clients which added support for OGC API - F
 
 !!! question "Interact with OGC API - Features via OWSLib"
 
-    If you do not have Python installed, consider running this exercise in a Docker container or in a cloud environment.
+    If you do not have Python installed, consider running this exercise in a Docker container. See the [Setup Chapter](../setup.md#using-docker-for-python-clients).
 
     <div class="termy">
     ```bash

--- a/workshop/content/docs/publishing/ogcapi-maps.md
+++ b/workshop/content/docs/publishing/ogcapi-maps.md
@@ -82,7 +82,7 @@ Run the following requests in your web browser:
 
 !!! question "Interact with OGC API - Maps via OWSLib"
 
-    If you do not have Python installed, consider running this exercise in a Docker container or in a cloud environment.
+    If you do not have Python installed, consider running this exercise in a Docker container. See the [Setup Chapter](../setup.md#using-docker-for-python-clients).
 
     <div class="termy">
     ```bash

--- a/workshop/content/docs/publishing/ogcapi-records.md
+++ b/workshop/content/docs/publishing/ogcapi-records.md
@@ -105,7 +105,7 @@ QGIS supports OGC API - Records via the [MetaSearch plugin](https://docs.qgis.or
 
 !!! question "Interact with OGC API - Records via OWSLib"
 
-    If you do not have Python installed, consider running this exercise in a Docker container or in a cloud environment.
+    If you do not have Python installed, consider running this exercise in a Docker container. See the [Setup Chapter](../setup.md#using-docker-for-python-clients).
 
     <div class="termy">
     ```bash

--- a/workshop/content/docs/setup.md
+++ b/workshop/content/docs/setup.md
@@ -77,7 +77,7 @@ system the Docker website provides detailed installation instructions. Please fo
     
     In our texts we will use `docker-compose`. Depending on your installation you may need
     to replace the hyphen (`-`) with a space. But you can always install the original
-    compose (`docker-compose`) via `pip install docker-compose`.
+    compose (`docker-compose`) via `pip3 install docker-compose`.
 
 For many platforms a product called `Docker Desktop` is available, which includes `Docker compose`:
 
@@ -234,17 +234,17 @@ In the next sections we will review additional examples of mounts to the data fo
 
 In some exercises we access `pygeoapi` remote endpoints using [OWSLib](https://owslib.readthedocs.io), 
 a Python library to interact with OGC Web Services. `OWSLib` can be installed using standard 
-Python `pip install OWSLib`, but you may not have Python available, or you want to keep your system 'clean'.
+Python `pip3 install OWSLib`, but you may not have Python available, or you want to keep your system 'clean'.
 
 As Docker is already available on your system, you can start up a 
-Container with a complete Python environment, and access it from a `Bash` shell prompt. 
+Container with a complete Python environment, and access it from a `bash` shell prompt. 
 The magic line is:
 
 `docker run -it --rm --network=host --name owslib python:3.10-slim /bin/bash`
 
 This will pull a small (125MB) official Python Docker Image. When the Container is started you are directed into 
 a `Bash` session/prompt. The argument `--network=host` allows you to directly interact with services on your
-host system, thus with `pygeoapi`, without setting up a Docker network. From there you can start `python` and install `OWSLib` and
+host system, thus with `pygeoapi`, without setting up a Docker network. From there you can start `python3`, install `OWSLib` and
 maybe even other tools like `curl` and `wget`.
 
 Below is a complete example, assuming pygeoapi runs on your `localhost` at port 5000:
@@ -264,8 +264,8 @@ de0194aa1c21: Pull complete
 Digest: sha256:7dc5b4e948acd18c1633b0e593ad0224298646612ce7d0b5ac6d4e17616d7e4b
 Status: Downloaded newer image for python:3.10-slim
 
-root@docker-desktop:/# pip install owslib
-root@docker-desktop:/# python
+root@docker-desktop:/# pip3 install owslib
+root@docker-desktop:/# python3
 >>> from owslib.ogcapi.features import Features
 >>> w = Features('http://localhost:5000')
 >>> w

--- a/workshop/content/docs/setup.md
+++ b/workshop/content/docs/setup.md
@@ -229,3 +229,52 @@ geopython/pygeoapi:latest
 </div>
 
 In the next sections we will review additional examples of mounts to the data folder. More Docker deployment examples can be found in the [pygeoapi GitHub repository](https://github.com/geopython/pygeoapi/tree/master/docker/examples).
+
+## Using Docker for Python Clients
+
+In some exercises we access `pygeoapi` remote endpoints using [OWSLib](https://owslib.readthedocs.io), 
+a Python library to interact with OGC Web Services. `OWSLib` can be installed using standard 
+Python `pip install OWSLib`, but you may not have Python available, or you want to keep your system 'clean'.
+
+As Docker is already available on your system, you can start up a 
+Container with a complete Python environment, and access it from a `Bash` shell prompt. 
+The magic line is:
+
+`docker run -it --rm --network=host --name owslib python:3.10-slim /bin/bash`
+
+This will pull a small (125MB) official Python Docker Image. When the Container is started you are directed into 
+a `Bash` session/prompt. The argument `--network=host` allows you to directly interact with services on your
+host system, thus with `pygeoapi`, without setting up a Docker network. From there you can start `python` and install `OWSLib` and
+maybe even other tools like `curl` and `wget`.
+
+Below is a complete example, assuming pygeoapi runs on your `localhost` at port 5000:
+
+
+<div class="termy">
+```bash
+docker run -it --rm --network=host --name owslib python:3.10-slim /bin/bash
+
+Unable to find image 'python:3.10-slim' locally
+3.10-slim: Pulling from library/python
+5b5fe70539cd: Pull complete 
+f4b0e4004dc0: Pull complete 
+c5424f0ac885: Pull complete 
+9d21fe1624ec: Pull complete 
+de0194aa1c21: Pull complete 
+Digest: sha256:7dc5b4e948acd18c1633b0e593ad0224298646612ce7d0b5ac6d4e17616d7e4b
+Status: Downloaded newer image for python:3.10-slim
+
+root@docker-desktop:/# pip install owslib
+root@docker-desktop:/# python
+>>> from owslib.ogcapi.features import Features
+>>> w = Features('http://localhost:5000')
+>>> w
+<owslib.ogcapi.features.Features object at 0x7ff493e6f850>
+>>> conformance = w.conformance()
+>>> conformance
+etc
+
+```
+</div>
+ 
+We will refer to this installation in some of the Exercises where OWSLib is used.


### PR DESCRIPTION
Extends the setup.md chapter with howto install/invoke OWSLib in a Python Docker Container and references/links to its anchor in all relevant Publication Chapters.