### PR TITLE
replace FOSS4G2023 with GISE (#110)

### DIFF
--- a/workshop/content/docs/conclusion.md
+++ b/workshop/content/docs/conclusion.md
@@ -11,15 +11,9 @@ goal is enabling low barrier, simple and flexible data publishing, using the OGC
 
 [![OGC APIs banner](assets/images/OGC_APIs_banner.jpg){ width=40% }](https://ogcapi.ogc.org)
 
-# FOSS4G 2023
+# GISE Hub Winter School on OGC Stack
 
-For those in attendance at [FOSS4G 2023](https://2023.foss4g.org):
-
-- come to the [pygeoapi project status 2023](https://talks.osgeo.org/foss4g-2023/talk/7WYYYR) presentation on Friday 30 June at 11h30, in room Lumbardhi
-- come to the [How to secure pygeoapi and streamline protected OGC APIs](https://talks.osgeo.org/foss4g-2023/talk/ZEVKTG) presentation on Wednesday 28 June at 15h, in room UBT D / N112 - Second Floor
-- come to the [Implementing OGC API - Processes with prefect and pygeoapi](https://talks.osgeo.org/foss4g-2023/talk/XR8WAT) presentation on Friday 30 June at 14h, in room UBT C / N109 - Second Floor
-- come to the [Geoconnex.us: a standards based framework to discover water data](https://talks.osgeo.org/foss4g-2023/talk/LMNBLS) presentation on Thursday 29 June Ft 14h30, in room UBT C / N109 - Second Floor
-- the pygeoapi team will be at the [community sprint](https://wiki.osgeo.org/wiki/FOSS4G_2023_Community_Sprint) on 01-02 July. Come join us!
+Sending you all best wishes and enjoy the rest of the [GISE Hub Winter School on OGC Stack](https://drive.google.com/file/d/1Y4C-rX7OeihXSPXV2QjoUp5z6P_3oe5d/view)!
 
 # Contributing
 

--- a/workshop/content/docs/index.md
+++ b/workshop/content/docs/index.md
@@ -15,22 +15,18 @@ Version: 1.1
 
 This workshop covers a wide range of topics (install/setup/configuration, publishing, cloud, templating, plugins, etc.). Please see the left hand navigation for the table of contents.
 
-# Your [FOSS4G 2023](https://2023.foss4g.org) workshop team
+# Your [GISE Hub Winter School on OGC Stack](https://drive.google.com/file/d/1Y4C-rX7OeihXSPXV2QjoUp5z6P_3oe5d/view) workshop team
 
 <table>
     <tr>
+        <td><a href="https://twitter.com/doublebyte"><img width="150" src="https://avatars.githubusercontent.com/u/1038897?v=4"/></a></td>
         <td><a href="https://twitter.com/tomkralidis"><img width="150" src="https://avatars.githubusercontent.com/u/910430?v=4"/></a></td>
-        <td><a href="https://twitter.com/justb4"><img width="150" src="https://avatars.githubusercontent.com/u/582630?v=4"/></a></td>
-        <td><a href="https://twitter.com/pvangenuchten"><img width="150" src="https://avatars.githubusercontent.com/u/299829?v=4"/></a></td>
-        <td><a href="https://twitter.com/francbartoli"><img width="150" src="https://avatars.githubusercontent.com/u/560676?v=4"/></a></td>
-        <td><a href="https://twitter.com/tzotsos"><img width="150" src="https://avatars.githubusercontent.com/u/383944?v=4"/></a></td>
+        <td><a href="https://twitter.com/krishnaglodha"><img width="150" src="https://avatars.githubusercontent.com/u/47075664?v=4"/></a></td>
     </tr>
     <tr>
+        <td>Joana Simoes</td>
         <td>Tom Kralidis</td>
-        <td>Just van den Broecke</td>
-        <td>Paul van Genuchten</td>
-        <td>Francesco Bartoli</td>
-        <td>Angelos Tzotsos</td>
+        <td>Krishna Lodha</td>
     </tr>
 </table>
 


### PR DESCRIPTION
Initial updates for delivery of this workshop for [GISE Hub Winter School on OGC Stack](https://drive.google.com/file/d/1Y4C-rX7OeihXSPXV2QjoUp5z6P_3oe5d/view).