### PR TITLE
Replaced "queryables" by "properties" in OWSLib Features exercise.

### DIFF
--- a/workshop/content/docs/publishing/ogcapi-features.md
+++ b/workshop/content/docs/publishing/ogcapi-features.md
@@ -264,7 +264,7 @@ QGIS is one of the first GIS Desktop clients which added support for OGC API - F
     >>> lakes['description']
     'lakes of the world, public domain'
     >>> lakes_queryables = w.collection_queryables('lakes')
-    >>> len(lakes_queryables['queryables'])
+    >>> len(lakes_queryables['properties'])
     6
     >>> lakes_query = w.collection_items('lakes')
     >>> lakes_query['features'][0]['properties']


### PR DESCRIPTION

Addressing this issue: https://github.com/geopython/diving-into-pygeoapi/issues/127

```
`>>> len(queryables['queryables'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'queryables'
>>> len(queryables['properties'])
11`
```