### PR TITLE
Updated gitter link

### DIFF
--- a/workshop/content/docs/index.md
+++ b/workshop/content/docs/index.md
@@ -102,7 +102,7 @@ The workshop contents, wiki and issue tracker are managed on GitHub at [https://
 
 # Support
 
-A [Gitter](https://matrix.to/#/#geopython_diving-into-pygeoapi:gitter.im) channel exists for
+A [Gitter](https://app.gitter.im/#/room/#geopython_diving-into-pygeoapi:gitter.im) channel exists for
 discussion and live support from the developers of the workshop and other workshop participants.
 
 For issues/bugs/suggestions or improvements/contributions, please use the [GitHub issue tracker](https://github.com/geopython/diving-into-pygeoapi/issues).


### PR DESCRIPTION
Addressing this issue: https://github.com/geopython/diving-into-pygeoapi/issues/159

Updated gitter link to not use matrix, which requires the use of a client like element. The current link can be opened in a browser, without the need to install any specialised software.