### PR TITLE
Updated server limits key on pygeoapi configuration

### DIFF
--- a/workshop/exercises/pygeoapi.config.yml
+++ b/workshop/exercises/pygeoapi.config.yml
@@ -42,7 +42,9 @@ server:
     language: en-US
     cors: true
     pretty_print: true
-    limit: 10
+    limits:
+        default_items: 20
+        max_items: 50
     # templates: /path/to/templates
     map:
         url: https://tile.openstreetmap.org/{z}/{x}/{y}.png


### PR DESCRIPTION
The server limits key has changed and this configuration is no longer valid.