### PR TITLE
Exercise 5 (tiles) pygeoapi.config.yml id field must be objectid for …

### DIFF
--- a/workshop/exercises/pygeoapi.config.yml
+++ b/workshop/exercises/pygeoapi.config.yml
@@ -342,7 +342,7 @@ resources:
 #            - type: feature
 #              name: GeoJSON
 #              data: /data/hyderabad/greater_hyderabad_municipal_corporation_ward_Boundaries.geojson
-#              id_field: id
+#              id_field: objectid
 #            - type: tile
 #              name: MVT-tippecanoe
 #              data: /data/tiles/  # local directory tree


### PR DESCRIPTION
…features

```
pygeoapi  | KeyError: 'id'
pygeoapi  | [2025-07-14T14:33:29Z] {/pygeoapi/pygeoapi/provider/geojson.py:214} ERROR - item undefined not found
pygeoapi  | [2025-07-14T14:33:29Z] {/pygeoapi/pygeoapi/api/__init__.py:589} ERROR - identifier not found
pygeoapi  | Traceback (most recent call last):
pygeoapi  |   File "/pygeoapi/pygeoapi/api/itemtypes.py", line 882, in get_collection_item
pygeoapi  |     content = p.get(
pygeoapi  |   File "/pygeoapi/pygeoapi/util.py", line 822, in get_geojsonf
pygeoapi  |     result = func(*args, **kwargs)
pygeoapi  |   File "/pygeoapi/pygeoapi/provider/geojson.py", line 215, in get
pygeoapi  |     raise ProviderItemNotFoundError(err)
pygeoapi  | pygeoapi.provider.base.ProviderItemNotFoundError: item undefined not found
pygeoapi  | [2025-07-14T14:33:29Z] {/pygeoapi/pygeoapi/provider/geojson.py:214} ERROR - item undefined not found
pygeoapi  | [2025-07-14T14:33:29Z] {/pygeoapi/pygeoapi/api/__init__.py:589} ERROR - identifier not found
pygeoapi  | Traceback (most recent call last):
pygeoapi  |   File "/pygeoapi/pygeoapi/api/itemtypes.py", line 882, in get_collection_item
pygeoapi  |     content = p.get(
pygeoapi  |   File "/pygeoapi/pygeoapi/util.py", line 822, in get_geojsonf
pygeoapi  |     result = func(*args, **kwargs)
pygeoapi  |   File "/pygeoapi/pygeoapi/provider/geojson.py", line 215, in get
pygeoapi  |     raise ProviderItemNotFoundError(err)
pygeoapi  | pygeoapi.provider.base.ProviderItemNotFoundError: item undefined not found
pygeoapi  | [2025-07-14T14:34:20Z] {/pygeoapi/pygeoapi/api/__init__.py:589} ERROR - identifier not found
p
```

Changing `id` to `objectid` fixes this problem.