### PR TITLE
Running exercises from codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,7 @@
 {
-  "name": "pygeoapi_container",
+  "name": "pygeoapi",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
-  },
-  "postStartCommand": "export PYGEOAPI_URL=https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}; docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "export PYGEOAPI_URL=\"https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\"; grep -q '^export PYGEOAPI_URL=' ~/.bashrc && sed -i '/^export PYGEOAPI_URL=/d' ~/.bashrc || true; echo \"export PYGEOAPI_URL=$PYGEOAPI_URL\" >> ~/.bashrc; until docker info >/dev/null 2>&1; do sleep 1; done; docker compose -f workshop/exercises/docker-compose.yml up -d"
+  "postStartCommand": "export PYGEOAPI_URL=\"https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\"; echo \"export PYGEOAPI_URL=$PYGEOAPI_URL\" >> ~/.bashrc; until docker info >/dev/null 2>&1; do sleep 1; done; docker compose -f workshop/exercises/docker-compose.yml up -d"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,6 @@
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
-  }
+  },
+  "postStartCommand": "until docker info >/dev/null 2>&1; do sleep 1; done; docker compose -f workshop/exercises/docker-compose.yml up -d"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "pygeoapi",
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "image": "mcr.microsoft.com/devcontainers/python:1",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,6 @@
   "image": "mcr.microsoft.com/devcontainers/universal:2",
   "forwardPorts": [5000],
   "features": {
-    "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.12"
-    },
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
   "postStartCommand": "docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "pygeoapi",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "image": "mcr.microsoft.com/devcontainers/base:python:3.12",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,8 @@
 {
   "name": "pygeoapi",
-  "image": "geopython/pygeoapi:latest",
   "forwardPorts": [5000],
-  "mounts": [
-    "source=${localWorkspaceFolder}/pygeoapi.config.yml,target=/pygeoapi/local.config.yml,type=bind",
-    "source=${localWorkspaceFolder}/data,target=/data,type=bind",
-    "source=${localWorkspaceFolder}/plugins/process/squared.py,target=/pygeoapi/pygeoapi/process/squared.py,type=bind"
-  ],
-  "postStartCommand": ""
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  },
+  "postStartCommand": "export PYGEOAPI_URL='pygeoapi' && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d && "
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "pygeoapi",
+  "image": "geopython/pygeoapi:latest",
+  "forwardPorts": [5000],
+  "mounts": [
+    "source=${localWorkspaceFolder}/pygeoapi.config.yml,target=/pygeoapi/local.config.yml,type=bind",
+    "source=${localWorkspaceFolder}/data,target=/data,type=bind",
+    "source=${localWorkspaceFolder}/plugins/process/squared.py,target=/pygeoapi/pygeoapi/process/squared.py,type=bind"
+  ],
+  "postStartCommand": ""
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "echo \"PYGEOAPI_URL=https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\" | sudo tee /etc/environment >/dev/null; until docker info >/dev/null 2>&1; do sleep 1; done; docker compose -f workshop/exercises/docker-compose.yml up -d"
+  "postStartCommand": "export PYGEOAPI_URL=\"https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\"; until docker info >/dev/null 2>&1; do sleep 1; done; docker compose -f workshop/exercises/docker-compose.yml up -d"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,11 @@
 {
   "name": "pygeoapi",
-  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
   "forwardPorts": [5000],
   "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12"
+    },
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
   "postStartCommand": "docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "pygeoapi",
-  "image": "geopython/geopython-workshop:latest",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/python:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
   "name": "pygeoapi",
   "image": "geopython/geopython-workshop:latest",
-  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "pygeoapi",
-  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,9 @@
 {
   "name": "pygeoapi",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "sleep 1; docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
+  "postStartCommand": "docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "until docker info >/dev/null 2>&1; do sleep 1; done; docker info"
+  "postStartCommand": "until docker info >/dev/null 2>&1; do sleep 1; done; docker info && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,8 @@
 {
   "name": "pygeoapi",
-  "image": "geopython/geopython-workshop:latest",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "export PYGEOAPI_URL=https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}; docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
+  "postStartCommand": "export PYGEOAPI_URL=https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "until docker info >/dev/null 2>&1; do sleep 1; done; docker compose -f workshop/exercises/docker-compose.yml up -d"
+  "postStartCommand": "echo \"PYGEOAPI_URL=https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\" | sudo tee /etc/environment >/dev/null; until docker info >/dev/null 2>&1; do sleep 1; done; docker compose -f workshop/exercises/docker-compose.yml up -d"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "export PYGEOAPI_URL=\"https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\"; until docker info >/dev/null 2>&1; do sleep 1; done; docker compose -f workshop/exercises/docker-compose.yml up -d"
+  "postStartCommand": "export PYGEOAPI_URL=\"https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\"; grep -q '^export PYGEOAPI_URL=' ~/.bashrc && sed -i '/^export PYGEOAPI_URL=/d' ~/.bashrc || true; echo \"export PYGEOAPI_URL=$PYGEOAPI_URL\" >> ~/.bashrc; until docker info >/dev/null 2>&1; do sleep 1; done; docker compose -f workshop/exercises/docker-compose.yml up -d"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "until docker info >/dev/null 2>&1; do sleep 1; done; docker info && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
+  "postStartCommand": "do sleep 1; done; docker info; docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "pygeoapi",
-  "image": "mcr.microsoft.com/devcontainers/python:1",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "pygeoapi",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "image": "geopython/geopython-workshop:latest",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/python:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "docker info"
+  "postStartCommand": "until docker info >/dev/null 2>&1; do sleep 1; done; docker info"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
+  "postStartCommand": "export PYGEOAPI_URL=https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}; docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "export PYGEOAPI_URL='pygeoapi' && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d && "
+  "postStartCommand": "export PYGEOAPI_URL='pygeoapi' && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d "
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "name": "pygeoapi",
   "image": "geopython/geopython-workshop:latest",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d logs"
+  "postStartCommand": "docker info"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d "
+  "postStartCommand": "docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d logs"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "do sleep 1; done; docker info; docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
+  "postStartCommand": "sleep 1; docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "export PYGEOAPI_URL='pygeoapi' && docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d "
+  "postStartCommand": "docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d "
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "pygeoapi",
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "image": "geopython/geopython-workshop:latest",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "pygeoapi",
-  "image": "mcr.microsoft.com/devcontainers/base:python:3.12",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
-  "name": "pygeoapi",
+  "name": "pygeoapi_container",
   "forwardPorts": [5000],
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "export PYGEOAPI_URL=https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+  "postStartCommand": "export PYGEOAPI_URL=https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}; docker compose -f /workspaces/${localWorkspaceFolderBasename}/workshop/exercises/docker-compose.yml up -d"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "postStartCommand": "export PYGEOAPI_URL=\"https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\"; echo \"export PYGEOAPI_URL=$PYGEOAPI_URL\" >> ~/.bashrc; until docker info >/dev/null 2>&1; do sleep 1; done; docker compose -f workshop/exercises/docker-compose.yml up -d"
+  "postStartCommand": "export PYGEOAPI_URL=\"https://${CODESPACE_NAME}-5000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\"; echo \"export PYGEOAPI_URL=$PYGEOAPI_URL\" >> ~/.bashrc; unzip workshop/exercises/data/brazil/guama_river.gpkg.zip -d workshop/exercises/data/brazil; until docker info >/dev/null 2>&1; do sleep 1; done; docker compose -f workshop/exercises/docker-compose.yml up -d"
 }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ zensical serve  # website is made available on http://localhost:8000
 You can also use Github Codespaces after forking the repository:
 <img width="964" height="269" alt="image" src="https://github.com/user-attachments/assets/e041edd6-c7cc-48ce-b5ea-f7bf7a1cbb7c" />
 
-You can use Terminal as usually. Navigate to exercises folder with ```cd workshop/exercises``` to proceed with the exercises. Docker container is already started from that folder:
+You can use Terminal as usually. Navigate to exercises folder with ```cd workshop/exercises``` to proceed with the exercises. Docker container is already started from that folder. If you want to make changes to pygeoapi.config.yml, you can run ```docker compose down``` from the exercise folder, make your changes and restart it with ```docker compose up -d```.
 <img width="1409" height="738" alt="image" src="https://github.com/user-attachments/assets/28090661-e9c8-4e94-b093-6171af4f4173" />
 
 Then you can open port 5000 in the browser:

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ zensical serve  # website is made available on http://localhost:8000
 You can also use Github Codespaces after forking the repository:
 <img width="964" height="269" alt="image" src="https://github.com/user-attachments/assets/e041edd6-c7cc-48ce-b5ea-f7bf7a1cbb7c" />
 
-You can use Terminal as usually. Navigate to exercises folder with ```cd workshop/exercises``` to proceed with the exercises. Docker container is already started from that folder. If you want to make changes to pygeoapi.config.yml, you can run ```docker compose down``` from the exercise folder, make your changes and restart it with ```docker compose up -d```.
-<img width="1409" height="738" alt="image" src="https://github.com/user-attachments/assets/28090661-e9c8-4e94-b093-6171af4f4173" />
-
 Then you can open port 5000 in the browser:
 <img width="1408" height="736" alt="image" src="https://github.com/user-attachments/assets/f790c911-3c12-41f3-91a9-41fb4bc76cce" />
+
+You can use Terminal as usually. Navigate to exercises folder with ```cd workshop/exercises``` to proceed with the exercises. Docker container is already started from that folder. If you want to make changes to pygeoapi.config.yml, you can run ```docker compose down``` (from the same exercise folder), make your changes and restart it with ```docker compose up -d```.
+<img width="1409" height="738" alt="image" src="https://github.com/user-attachments/assets/28090661-e9c8-4e94-b093-6171af4f4173" />
 
 
 ### Translating the workshop to a different language

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can also use Github Codespaces after forking the repository:
 <img width="964" height="269" alt="image" src="https://github.com/user-attachments/assets/e041edd6-c7cc-48ce-b5ea-f7bf7a1cbb7c" />
 
 Then you can open port 5000 in the browser:
-<img width="1408" height="736" alt="image" src="https://github.com/user-attachments/assets/f790c911-3c12-41f3-91a9-41fb4bc76cce" />
+<img width="1402" height="728" alt="image" src="https://github.com/user-attachments/assets/2ce9fc13-fbc0-4e95-8da1-a2362907a0c6" />
 
 You can use Terminal as usually. Navigate to exercises folder with ```cd workshop/exercises``` to proceed with the exercises. Docker container is already started from that folder. If you want to make changes to pygeoapi.config.yml, you can run ```docker compose down``` (from the same exercise folder), make your changes and restart it with ```docker compose up -d```.
 <img width="1409" height="738" alt="image" src="https://github.com/user-attachments/assets/28090661-e9c8-4e94-b093-6171af4f4173" />

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ zensical build
 zensical serve  # website is made available on http://localhost:8000
 ```
 
+### Running from Github Codespaces
+
+You can also use Github Codespaces after forking the repository:
+<img width="964" height="269" alt="image" src="https://github.com/user-attachments/assets/e041edd6-c7cc-48ce-b5ea-f7bf7a1cbb7c" />
+
+You can use Terminal as usually. Navigate to exercises folder with ```cd workshop/exercises``` to proceed with the exercises. Docker container is already started from that folder:
+<img width="1409" height="738" alt="image" src="https://github.com/user-attachments/assets/28090661-e9c8-4e94-b093-6171af4f4173" />
+
+Then you can open port 5000 in the browser:
+<img width="1408" height="736" alt="image" src="https://github.com/user-attachments/assets/f790c911-3c12-41f3-91a9-41fb4bc76cce" />
+
+
 ### Translating the workshop to a different language
 
 Support to multiple languages is native in Zensical. To add an additional language to the workshop, create another toml file with the locale code as part of the filename. See an example [here](./workshop/content/zensical.pt.toml). 

--- a/workshop/exercises/docker-compose.yml
+++ b/workshop/exercises/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     image: geopython/pygeoapi:latest
     container_name: pygeoapi
     environment:
-      - PYGEOAPI_URL: ${PYGEOAPI_URL}
+      PYGEOAPI_URL: ${PYGEOAPI_URL}
 
     ports:
       - 5000:80

--- a/workshop/exercises/docker-compose.yml
+++ b/workshop/exercises/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     image: geopython/pygeoapi:latest
     container_name: pygeoapi
     environment:
-      PYGEOAPI_URL: ${PYGEOAPI_URL}
+      PYGEOAPI_URL: ${PYGEOAPI_URL:-http://localhost:5000}
 
     ports:
       - 5000:80

--- a/workshop/exercises/docker-compose.yml
+++ b/workshop/exercises/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   pygeoapi:
     image: geopython/pygeoapi:latest
 
-    container_name: diving-into-pygeoapi
+    container_name: pygeoapi
 
     ports:
       - 5000:80

--- a/workshop/exercises/docker-compose.yml
+++ b/workshop/exercises/docker-compose.yml
@@ -34,8 +34,9 @@
 services:
   pygeoapi:
     image: geopython/pygeoapi:latest
-
     container_name: pygeoapi
+    environment:
+      - PYGEOAPI_URL: ${PYGEOAPI_URL}
 
     ports:
       - 5000:80

--- a/workshop/exercises/docker-compose.yml
+++ b/workshop/exercises/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   pygeoapi:
     image: geopython/pygeoapi:latest
 
-    container_name: pygeoapi
+    container_name: diving-into-pygeoapi
 
     ports:
       - 5000:80

--- a/workshop/exercises/pygeoapi.config.yml
+++ b/workshop/exercises/pygeoapi.config.yml
@@ -34,7 +34,7 @@
 server:
     bind:
         host: 0.0.0.0
-        port: 80
+        port: 5000
     url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
     encoding: utf-8

--- a/workshop/exercises/pygeoapi.config.yml
+++ b/workshop/exercises/pygeoapi.config.yml
@@ -34,7 +34,7 @@
 server:
     bind:
         host: 0.0.0.0
-        port: 80
+        port: 5000
     url: ${PYGEOAPI_URL:-http://localhost:5000}
     mimetype: application/json; charset=UTF-8
     encoding: utf-8

--- a/workshop/exercises/pygeoapi.config.yml
+++ b/workshop/exercises/pygeoapi.config.yml
@@ -35,7 +35,7 @@ server:
     bind:
         host: 0.0.0.0
         port: 80
-    url: http://localhost:5000/
+    url: ${PYGEOAPI_URL:-http://localhost:5000}
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     gzip: false

--- a/workshop/exercises/pygeoapi.config.yml
+++ b/workshop/exercises/pygeoapi.config.yml
@@ -35,7 +35,7 @@ server:
     bind:
         host: 0.0.0.0
         port: 5000
-    url: http://{$PYGEOAPI_URL:-localhost}:5000/
+    url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     gzip: false

--- a/workshop/exercises/pygeoapi.config.yml
+++ b/workshop/exercises/pygeoapi.config.yml
@@ -35,7 +35,7 @@ server:
     bind:
         host: 0.0.0.0
         port: 5000
-    url: http://localhost:5000/
+    url: http://{$PYGEOAPI_URL:-localhost}:5000/
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     gzip: false

--- a/workshop/exercises/pygeoapi.config.yml
+++ b/workshop/exercises/pygeoapi.config.yml
@@ -34,7 +34,7 @@
 server:
     bind:
         host: 0.0.0.0
-        port: 5000
+        port: 80
     url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
     encoding: utf-8


### PR DESCRIPTION
Changes summary:
1. `export PYGEOAPI_URL=` is set in PostStartCommand to set the variable in the same shell that `docker compose` is running afterwards
2. `echo \"export PYGEOAPI_URL=$PYGEOAPI_URL\" >> ~/.bashrc` is saving variable globally, so after manually stopping and restarting docker in the Terminal, variable is still accessible
3. `docker compose` is running in the same start command - users will have it running on the port 5000 right after creating a Codespace. They can navigate to workshop/exercises and `docker compose down`
4. Env variable `PYGEOAPI_URL` is injected into docker-compose with default value (in case user is running locally)
5. README instructions updated

Note: added `until docker info >/dev/null 2>&1; do sleep 1; done; ` compared to geopython workshop, as in this case docker takes longer to start (probably because the default image is used to run Codespaces container)