### PR TITLE
Exercise 4: add feature provider to map example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .DS_Store
 workshop/exercises/data/tiles
+workshop/exercises/data/brazil/guama_river.gpkg
+workshop/exercises/data/airport.gpkg-*
+workshop/exercises/data/tartu/metadata/load_tinydb_records.py
 workshop/content/.cache
 workshop/content/site
-
 .idea
 .venv

--- a/workshop/content/docs/publishing/ogcapi-maps.md
+++ b/workshop/content/docs/publishing/ogcapi-maps.md
@@ -59,11 +59,20 @@ In this section we'll be exposing a Geopackage file available at `workshop/exerc
               format:
                   name: png
                   mimetype: image/png
+            - type: feature
+              name: SQLiteGPKG
+              data: /data/airport.gpkg
+              id_field: fid
+              table: airport
     ```
 
 !!! note
 
     See [the official documentation](https://docs.pygeoapi.io/en/latest/publishing/ogcapi-maps.html) for more information on supported map backends
+
+!!! note
+
+    The airport data is published as **both** a map and a feature collection through a single endpoint (`/collections/airports`).  How is this made possible in the above configuration?
 
 ## pygeoapi as a WMS proxy
 

--- a/workshop/exercises/pygeoapi.config.yml
+++ b/workshop/exercises/pygeoapi.config.yml
@@ -315,11 +315,11 @@ resources:
 #                  name: png
 #                  mimetype: image/png
 #              storage_crs: http://www.opengis.net/def/crs/EPSG/0/4326
-#             - type: feature
-#               name: SQLiteGPKG
-#               data: /data/airport.gpkg
-#               id_field: fid
-#               table: airport
+#            - type: feature
+#              name: SQLiteGPKG
+#              data: /data/airport.gpkg
+#              id_field: fid
+#              table: airport
 ## END - EXERCISE 4 - Maps
 
 ## START - EXERCISE 5 - Tiles

--- a/workshop/exercises/pygeoapi.config.yml
+++ b/workshop/exercises/pygeoapi.config.yml
@@ -315,6 +315,11 @@ resources:
 #                  name: png
 #                  mimetype: image/png
 #              storage_crs: http://www.opengis.net/def/crs/EPSG/0/4326
+#             - type: feature
+#               name: SQLiteGPKG
+#               data: /data/airport.gpkg
+#               id_field: fid
+#               table: airport
 ## END - EXERCISE 4 - Maps
 
 ## START - EXERCISE 5 - Tiles


### PR DESCRIPTION
This PR adds a feature provider to Exercise 4 to demonstrate the ability for one OGC API Collection to be served via multiple APIs (maps, features).